### PR TITLE
Tags select2

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -11,6 +11,7 @@ class IdeasController < ApplicationController
 
   def new
     @idea = Idea.new
+    @tags = ActsAsTaggableOn::Tag.all.order('name').map{ |tag| tag.name }
   end
 
   def edit
@@ -35,7 +36,7 @@ class IdeasController < ApplicationController
   private
 
   def idea_params
-    params.require('idea').permit(:title, :description, :tag_list, photos: [])
+    params.require('idea').permit(:title, :description, tag_list: [], photos: [])
   end
 
   def set_idea

--- a/app/javascript/components/select2.js
+++ b/app/javascript/components/select2.js
@@ -6,6 +6,7 @@ import 'select2-theme-bootstrap4/dist/select2-bootstrap.css'
 
 const initSelect2 = () => {
   $('.tagsSelection').select2({
+    placeholder: "Add tags",
     tags: true,
     tokenSeparators: [',', ' '],
     theme: "bootstrap"

--- a/app/javascript/components/select2.js
+++ b/app/javascript/components/select2.js
@@ -1,0 +1,15 @@
+import $ from 'jquery';
+import 'select2';
+import 'select2/dist/css/select2.css'
+import 'select2-theme-bootstrap4/dist/select2-bootstrap.css'
+
+
+const initSelect2 = () => {
+  $('.tagsSelection').select2({
+    tags: true,
+    tokenSeparators: [',', ' '],
+    theme: "bootstrap"
+  });
+};
+
+export { initSelect2 };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,4 +1,13 @@
 import "bootstrap";
 import {selectorShow} from "../components/selector_show";
+import {initSelect2} from "../components/select2";
 
 selectorShow();
+
+$(document).ready(function() {
+  if (document.querySelector('.tagsSelection')){
+    initSelect2();
+  }
+});
+
+

--- a/app/views/ideas/new.html.erb
+++ b/app/views/ideas/new.html.erb
@@ -1,10 +1,14 @@
+
 <div class="new-idea-container my-3">
     <h1 class='new-idea-container-container__title'>Your amazing idea</h1>
     <div class="new-idea-form-container bg-white p-3">
       <%= simple_form_for @idea do |f| %>
         <%= f.input :title, placeholder: 'A billion dollars idea !' %>
         <%= f.input :description, placeholder: 'I want to make people very rich !!!' %>
-        <%= f.input :tag_list, placeholder: 'Seperate tags with ,' %>
+        <%= f.input :tag_list, placeholder: 'Seperate tags with ,' ,
+                     input_html: { class: 'tagsSelection', multiple: "multiple" },
+                     collection: @tags
+                     %>
         <%= f.input :photos, as: :file,
                     required: true,
                     input_html: { multiple: true, autocomplete: "your desired picture", class: 'd-none' },

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= csrf_meta_tags %>
     <%= action_cable_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%#= stylesheet_pack_tag 'application', media: 'all' %> <!-- Uncomment if you import CSS in app/javascript/packs/application.js -->
+    <%= stylesheet_pack_tag 'application', media: 'all' %> <!-- Uncomment if you import CSS in app/javascript/packs/application.js -->
   </head>
   <body>
     <% if !current_page?(root_url) %>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.4.1",
     "jquery": "^3.4.1",
-    "popper.js": "^1.16.0"
+    "popper.js": "^1.16.0",
+    "select2": "^4.0.12",
+    "select2-theme-bootstrap4": "^0.2.0-beta.4"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6136,6 +6136,16 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
+select2-theme-bootstrap4@^0.2.0-beta.4:
+  version "0.2.0-beta.4"
+  resolved "https://registry.yarnpkg.com/select2-theme-bootstrap4/-/select2-theme-bootstrap4-0.2.0-beta.4.tgz#3f263294e72abf0c36cd998f16f1c532c6a309d7"
+  integrity sha512-FG9GJdd1syjVvWxkvTrZnEFTvdvyKlBuObLnmRoY2RxQICqcnKdhkUlweGlifdsWJYiWHF342WeGKP5fGJhDQA==
+
+select2@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/select2/-/select2-4.0.12.tgz#9c0492d4d06948f2bd079f6e14718a41c7eaa60e"
+  integrity sha512-mbXC05AvjCboZcRlgJqN4mlI2qmqshpRC76sKNAdxS1lPLOh2m/NTyfL6xsvGoY6eIhjaya4dbumN99MudVQ2w==
+
 selfsigned@^1.10.7:
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.7.tgz#da5819fd049d5574f28e88a9bcc6dbc6e6f3906b"


### PR DESCRIPTION
@basilequinchon 
J'ai ajouté select2 pour la sélection des tags.
C'est plus intuitif d'ajouter des tags avec select2, il n'y a plus besoin de mettre un séparateur.
Néanmoins lorsque l'utilisateur doit entrer plusieurs tags, il peut le faire en tapant l'une des touches : 
- Espace
- Virgule
- Entrée

Une démo vaut plus que des mots :

![](http://g.recordit.co/OYeQoV288K.gif)

Par contre il y à un bug si la validation du formulaire ne passe pas, l'input de type select disparait complètement de la page et donc select2 n'arrive pas à s'initialiser (on voit une erreur dans la console) et ça créé un 1 seul tag avec tous les tags concaténés.
![](http://g.recordit.co/jLpQ0Ey3kP.gif)
